### PR TITLE
[FEATURE][PFG5-59] Add cors origin allow

### DIFF
--- a/src/main/java/com/capitravel/Capitravel/WebConfig.java
+++ b/src/main/java/com/capitravel/Capitravel/WebConfig.java
@@ -1,0 +1,20 @@
+package com.capitravel.Capitravel;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**").allowedOrigins("*");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Se añaden los cors origin para poder consumir la api desde el front, adjunto front de test demostrando su funcionamiento.

![image](https://github.com/user-attachments/assets/fa5f731f-7ad5-4488-9708-f333e9f796b1)
