### PR TITLE
[FEATURE][PFG5-69] add validate duplicated ids

### DIFF
--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
 @Service
 public class ExperienceServiceImpl implements ExperienceService {
 
+    public static final String CATEGORIES_FIELD_NAME = "Categories";
+    public static final String PROPERTIES_FIELD_NAME = "Properties";
     @Autowired
     private ExperienceRepository experienceRepository;
 
@@ -48,8 +50,8 @@ public class ExperienceServiceImpl implements ExperienceService {
             throw new DuplicatedResourceException("An experience with title " + experienceDTO.getTitle() + " already exists");
         }
 
-        validateNoDuplicates(experienceDTO.getCategoryIds(), "Category");
-        validateNoDuplicates(experienceDTO.getPropertyIds(), "Property");
+        validateNoDuplicates(experienceDTO.getCategoryIds(), CATEGORIES_FIELD_NAME);
+        validateNoDuplicates(experienceDTO.getPropertyIds(), PROPERTIES_FIELD_NAME);
 
         List<Category> categories = experienceDTO.getCategoryIds().stream()
                 .map(categoryId -> categoryRepository.findById(categoryId)
@@ -85,8 +87,8 @@ public class ExperienceServiceImpl implements ExperienceService {
             throw new DuplicatedResourceException("An experience with title " + updatedExperienceDTO.getTitle() + " already exists");
         }
 
-        validateNoDuplicates(updatedExperienceDTO.getCategoryIds(), "Category");
-        validateNoDuplicates(updatedExperienceDTO.getPropertyIds(), "Property");
+        validateNoDuplicates(updatedExperienceDTO.getCategoryIds(), CATEGORIES_FIELD_NAME);
+        validateNoDuplicates(updatedExperienceDTO.getPropertyIds(), PROPERTIES_FIELD_NAME);
 
         List<Category> categories = updatedExperienceDTO.getCategoryIds().stream()
                 .map(categoryId -> categoryRepository.findById(categoryId)
@@ -123,7 +125,7 @@ public class ExperienceServiceImpl implements ExperienceService {
     private void validateNoDuplicates(List<Long> ids, String fieldName) {
         Set<Long> uniqueIds = new HashSet<>(ids);
         if (uniqueIds.size() < ids.size()) {
-            throw new DuplicatedResourceException("Duplicate " + fieldName + " IDs are not allowed.");
+            throw new DuplicatedResourceException("Duplicated " + fieldName + " are not allowed.");
         }
     }
 

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -13,8 +13,10 @@ import com.capitravel.Capitravel.service.ExperienceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -45,6 +47,9 @@ public class ExperienceServiceImpl implements ExperienceService {
         if (experienceRepository.existsByTitle(experienceDTO.getTitle())) {
             throw new DuplicatedResourceException("An experience with title " + experienceDTO.getTitle() + " already exists");
         }
+
+        validateNoDuplicates(experienceDTO.getCategoryIds(), "Category");
+        validateNoDuplicates(experienceDTO.getPropertyIds(), "Property");
 
         List<Category> categories = experienceDTO.getCategoryIds().stream()
                 .map(categoryId -> categoryRepository.findById(categoryId)
@@ -80,6 +85,9 @@ public class ExperienceServiceImpl implements ExperienceService {
             throw new DuplicatedResourceException("An experience with title " + updatedExperienceDTO.getTitle() + " already exists");
         }
 
+        validateNoDuplicates(updatedExperienceDTO.getCategoryIds(), "Category");
+        validateNoDuplicates(updatedExperienceDTO.getPropertyIds(), "Property");
+
         List<Category> categories = updatedExperienceDTO.getCategoryIds().stream()
                 .map(categoryId -> categoryRepository.findById(categoryId)
                         .orElseThrow(() -> new ResourceNotFoundException("Category not found with id: " + categoryId)))
@@ -110,6 +118,13 @@ public class ExperienceServiceImpl implements ExperienceService {
             throw new ResourceNotFoundException("The Experience for id: " + id + " was not found.");
         }
         experienceRepository.deleteById(id);
+    }
+
+    private void validateNoDuplicates(List<Long> ids, String fieldName) {
+        Set<Long> uniqueIds = new HashSet<>(ids);
+        if (uniqueIds.size() < ids.size()) {
+            throw new DuplicatedResourceException("Duplicate " + fieldName + " IDs are not allowed.");
+        }
     }
 
     private double getRandomReputation() {

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -25,6 +25,7 @@ public class ExperienceServiceImpl implements ExperienceService {
 
     public static final String CATEGORIES_FIELD_NAME = "Categories";
     public static final String PROPERTIES_FIELD_NAME = "Properties";
+
     @Autowired
     private ExperienceRepository experienceRepository;
 


### PR DESCRIPTION
Adding validations to avoid adding duplicated category or property ids
creation CategoryIds validation:
![image](https://github.com/user-attachments/assets/667c66a1-ae82-462e-bd8b-9ffa94841eca)

creation PropertyIds validation:
![image](https://github.com/user-attachments/assets/3eee23bf-2d66-40fa-aa22-18f02a53d477)

update CategoryIds validation:
![image](https://github.com/user-attachments/assets/7e43a6d8-51fc-4378-950b-2da9e5274003)

update PropertyIdsValidation:
![image](https://github.com/user-attachments/assets/448052fa-afe1-421a-9d18-118dd0315e10)
