### PR TITLE
Feature/pfg5 100 experiences by categories

### DIFF
--- a/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
+++ b/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
@@ -31,6 +31,11 @@ public class ExperienceController {
         return experience != null ? ResponseEntity.ok(experience) : ResponseEntity.notFound().build();
     }
 
+    @GetMapping("/by-category/{categoryId}")
+    public List<Experience>getExperiencesByCategories(@PathVariable Long categoryId) {
+        return experienceService.getExperiencesByCategories(categoryId);
+    }
+
     @PostMapping
     public ResponseEntity<Experience> createExperience(@Valid @RequestBody ExperienceDTO experienceDTO) {
         Experience createdExperience = experienceService.createExperience(experienceDTO);

--- a/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
+++ b/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
@@ -11,6 +11,8 @@ public interface ExperienceService {
 
     Experience getExperienceById(Long id);
 
+    List<Experience> getExperiencesByCategories(Long categoryId);
+
     Experience createExperience(ExperienceDTO experience);
 
     Experience updateExperience(Long id, ExperienceDTO updatedExperience);

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -1,5 +1,6 @@
 package com.capitravel.Capitravel.service.impl;
 
+import ch.qos.logback.core.net.SyslogOutputStream;
 import com.capitravel.Capitravel.dto.ExperienceDTO;
 import com.capitravel.Capitravel.exception.DuplicatedResourceException;
 import com.capitravel.Capitravel.exception.ResourceNotFoundException;
@@ -9,6 +10,7 @@ import com.capitravel.Capitravel.model.Property;
 import com.capitravel.Capitravel.repository.CategoryRepository;
 import com.capitravel.Capitravel.repository.ExperienceRepository;
 import com.capitravel.Capitravel.repository.PropertyRepository;
+import com.capitravel.Capitravel.service.CategoryService;
 import com.capitravel.Capitravel.service.ExperienceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -27,6 +29,9 @@ public class ExperienceServiceImpl implements ExperienceService {
     public static final String PROPERTIES_FIELD_NAME = "Properties";
 
     @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
     private ExperienceRepository experienceRepository;
 
     @Autowired
@@ -43,6 +48,14 @@ public class ExperienceServiceImpl implements ExperienceService {
     @Override
     public Experience getExperienceById(Long id) {
         return experienceRepository.findById(id).orElse(null);
+    }
+
+    @Override
+    public List<Experience> getExperiencesByCategories(Long categoryId){
+
+        Category categoryById = categoryService.getCategoryById(categoryId);
+        return experienceRepository.findByCategoryId(categoryId);
+
     }
 
     @Override

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -1,6 +1,5 @@
 package com.capitravel.Capitravel.service.impl;
 
-import ch.qos.logback.core.net.SyslogOutputStream;
 import com.capitravel.Capitravel.dto.ExperienceDTO;
 import com.capitravel.Capitravel.exception.DuplicatedResourceException;
 import com.capitravel.Capitravel.exception.ResourceNotFoundException;
@@ -52,10 +51,8 @@ public class ExperienceServiceImpl implements ExperienceService {
 
     @Override
     public List<Experience> getExperiencesByCategories(Long categoryId){
-
         Category categoryById = categoryService.getCategoryById(categoryId);
         return experienceRepository.findByCategoryId(categoryId);
-
     }
 
     @Override


### PR DESCRIPTION
adding the endpoint /experiences/by-category/{categoryId}.

Handle the 404 Not Found exception when searching for a non-existent categoryId:

![image](https://github.com/user-attachments/assets/8a41a502-e281-4984-be44-131a3e76be28)

Response for an existent categoryId with experiences (Return a list of experiences):

![image](https://github.com/user-attachments/assets/7a10be9a-a3a1-47aa-ac1c-06260c65413b)

Response for an existent categoryId with no experiences (Return void):

![image](https://github.com/user-attachments/assets/cd0cd54c-f0b1-447a-8cea-d86f40ad86fd)


