### PR TITLE
[FEATURE][PFG5-70] Mismatch exception when trying to use parameters with wrong type

### DIFF
--- a/src/main/java/com/capitravel/Capitravel/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capitravel/Capitravel/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -68,5 +69,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({ BadCredentialsException.class })
     public ResponseEntity<String> handleBadCredentialsException(Exception ex) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid username or password");
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Map<String, String>> handleTypeMismatchException(MethodArgumentTypeMismatchException ex) {
+        Map<String, String> error = new HashMap<>();
+
+        String paramName = ex.getName();
+        String expectedType = ex.getRequiredType() != null ? ex.getRequiredType().getSimpleName() : "expected value";
+
+        error.put("error", "Invalid format for parameter '" + paramName + "'. Expected a " + expectedType + ".");
+
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 }


### PR DESCRIPTION
Added mismatch exception handler
It is throwed when you try to request a parameter with the wrong type

The exception handler is generic and it applies to any parameter on any entity and any request method.

![image](https://github.com/user-attachments/assets/5a0bb056-9b47-4030-852d-9cbf4a040dfa)
![image](https://github.com/user-attachments/assets/22194460-e13f-4d43-b36f-b7461b7cdf7e)
