### PR TITLE
Feature/pfg5 33 add query filters for experiences by category

### DIFF
--- a/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
+++ b/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
@@ -20,11 +20,6 @@ public class ExperienceController {
     @Autowired
     private ExperienceService experienceService;
 
-    // @GetMapping
-    //  public List<Experience> getAllExperiences() {
-    //     return experienceService.getAllExperiences();
-    //  }
-
     @GetMapping("/{id}")
     public ResponseEntity<Experience> getExperienceById(@PathVariable Long id) {
         Experience experience = experienceService.getExperienceById(id);

--- a/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
+++ b/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
@@ -20,10 +20,10 @@ public class ExperienceController {
     @Autowired
     private ExperienceService experienceService;
 
-    @GetMapping
-    public List<Experience> getAllExperiences() {
-        return experienceService.getAllExperiences();
-    }
+    // @GetMapping
+    //  public List<Experience> getAllExperiences() {
+    //     return experienceService.getAllExperiences();
+    //  }
 
     @GetMapping("/{id}")
     public ResponseEntity<Experience> getExperienceById(@PathVariable Long id) {
@@ -31,9 +31,13 @@ public class ExperienceController {
         return experience != null ? ResponseEntity.ok(experience) : ResponseEntity.notFound().build();
     }
 
-    @GetMapping("/by-category/{categoryId}")
-    public List<Experience>getExperiencesByCategories(@PathVariable Long categoryId) {
-        return experienceService.getExperiencesByCategories(categoryId);
+    @GetMapping
+    public List<Experience> getExperiences(@RequestParam(required = false) List<Long> categoryIds) {
+        if (categoryIds == null || categoryIds.isEmpty()) {
+            return experienceService.getAllExperiences();
+        } else {
+            return experienceService.getExperiencesByCategories(categoryIds);
+        }
     }
 
     @PostMapping

--- a/src/main/java/com/capitravel/Capitravel/repository/ExperienceRepository.java
+++ b/src/main/java/com/capitravel/Capitravel/repository/ExperienceRepository.java
@@ -2,9 +2,10 @@ package com.capitravel.Capitravel.repository;
 
 import com.capitravel.Capitravel.model.Experience;
 import org.springframework.data.jpa.repository.JpaRepository;
-import java.util.List;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
     boolean existsByTitle(String title);
@@ -14,4 +15,8 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
 
     @Query("SELECT e FROM Experience e JOIN e.properties p WHERE p.id = :propertyId")
     List<Experience> findByPropertyId(@Param("propertyId") Long propertyId);
+
+    @Query("SELECT e FROM Experience e JOIN e.categories c WHERE c.id IN :categoryIds")
+    List<Experience> findByCategoryIds(@Param("categoryIds") List<Long> categoryIds);
+
 }

--- a/src/main/java/com/capitravel/Capitravel/repository/ExperienceRepository.java
+++ b/src/main/java/com/capitravel/Capitravel/repository/ExperienceRepository.java
@@ -16,7 +16,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
     @Query("SELECT e FROM Experience e JOIN e.properties p WHERE p.id = :propertyId")
     List<Experience> findByPropertyId(@Param("propertyId") Long propertyId);
 
-    @Query("SELECT e FROM Experience e JOIN e.categories c WHERE c.id IN :categoryIds")
-    List<Experience> findByCategoryIds(@Param("categoryIds") List<Long> categoryIds);
+    @Query("SELECT e FROM Experience e JOIN e.categories c WHERE c.id IN :categoryIds GROUP BY e.id HAVING COUNT(c.id) = :categoryCount")
+    List<Experience> findByCategoryIds(@Param("categoryIds") List<Long> categoryIds, @Param("categoryCount") Long categoryCount);
 
 }

--- a/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
+++ b/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
@@ -11,7 +11,7 @@ public interface ExperienceService {
 
     Experience getExperienceById(Long id);
 
-    List<Experience> getExperiencesByCategories(Long categoryId);
+    List<Experience> getExperiencesByCategories(List<Long> categoryIds);
 
     Experience createExperience(ExperienceDTO experience);
 

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -14,10 +14,7 @@ import com.capitravel.Capitravel.service.ExperienceService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
@@ -50,9 +47,21 @@ public class ExperienceServiceImpl implements ExperienceService {
     }
 
     @Override
-    public List<Experience> getExperiencesByCategories(Long categoryId){
-        Category categoryById = categoryService.getCategoryById(categoryId);
-        return experienceRepository.findByCategoryId(categoryId);
+    public List<Experience> getExperiencesByCategories(List<Long> categoryIds) {
+        List<Long> validCategoryIds = new ArrayList<>();
+        List<Long> notFoundCategoryIds = new ArrayList<>();
+        for (Long categoryId : categoryIds) {
+            try {
+                categoryService.getCategoryById(categoryId);
+                validCategoryIds.add(categoryId);
+            } catch (Exception ex) {
+                notFoundCategoryIds.add(categoryId);
+            }
+        }
+        if (!notFoundCategoryIds.isEmpty()) {
+            throw new ResourceNotFoundException("Categories not found: " + notFoundCategoryIds);
+        }
+        return experienceRepository.findByCategoryIds(validCategoryIds);
     }
 
     @Override

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -50,18 +50,20 @@ public class ExperienceServiceImpl implements ExperienceService {
     public List<Experience> getExperiencesByCategories(List<Long> categoryIds) {
         List<Long> validCategoryIds = new ArrayList<>();
         List<Long> notFoundCategoryIds = new ArrayList<>();
+
         for (Long categoryId : categoryIds) {
             try {
                 categoryService.getCategoryById(categoryId);
                 validCategoryIds.add(categoryId);
-            } catch (Exception ex) {
+            } catch (Exception e) {
                 notFoundCategoryIds.add(categoryId);
             }
         }
         if (!notFoundCategoryIds.isEmpty()) {
             throw new ResourceNotFoundException("Categories not found: " + notFoundCategoryIds);
         }
-        return experienceRepository.findByCategoryIds(validCategoryIds);
+        Long categoryCount = (long) validCategoryIds.size();
+        return experienceRepository.findByCategoryIds(validCategoryIds, categoryCount);
     }
 
     @Override


### PR DESCRIPTION
Fix the experiences filter to accept query params. I need to identify which categories do not have associated experiences. I return a 404 Not found exception, with a list of categories, could not exist.

When everything is ok: (Return a list of exact associated experiences.)
![image](https://github.com/user-attachments/assets/4a66551d-268f-4d1d-a035-f91881fa0763)

When category exist but is not associated to exact experiences:
![image](https://github.com/user-attachments/assets/88d32821-471d-4a74-9617-7d7d8fdb9249)

When one or more category not exists:
![image](https://github.com/user-attachments/assets/65ff1740-56d8-4cab-80ed-6c7fd15cceb0)

