### PR TITLE
[FEATURE][PFG5-133] Implement experience search

### DIFF
--- a/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
+++ b/src/main/java/com/capitravel/Capitravel/controller/ExperienceController.java
@@ -36,7 +36,6 @@ public class ExperienceController {
             @RequestParam(required = false) List<Long> categoryIds,
             @RequestParam(required = false) String keywords,
             @RequestParam(required = false) String country,
-            @RequestParam(required = false) String city,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate) {
 
@@ -45,8 +44,8 @@ public class ExperienceController {
 
         if (categoryIds != null && !categoryIds.isEmpty()) {
             return experienceService.getExperiencesByCategories(categoryIds);
-        } else if (keywords != null || country != null || city != null || (startDate != null && endDate != null)) {
-            return experienceService.searchExperiences(keywords, country, city, startDateTime, endDateTime);
+        } else if (keywords != null || country != null || (startDate != null && endDate != null)) {
+            return experienceService.searchExperiences(keywords, country, startDateTime, endDateTime);
         } else {
             return experienceService.getAllExperiences();
         }

--- a/src/main/java/com/capitravel/Capitravel/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capitravel/Capitravel/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -84,5 +85,13 @@ public class GlobalExceptionHandler {
         error.put("error", "Invalid format for parameter '" + paramName + "'. Expected a " + expectedType + ".");
 
         return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<Map<String, String>> handleDateTimeParseException(DateTimeParseException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("error", "Invalid date format, should be yyyy-MM-dd or yyyy-MM-ddTHH-mm");
+        response.put("details", ex.getMessage());
+        return ResponseEntity.badRequest().body(response);
     }
 }

--- a/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
+++ b/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
@@ -21,5 +21,5 @@ public interface ExperienceService {
 
     void deleteExperience(Long id);
 
-    List<Experience> searchExperiences(String keywords, String country, String city, LocalDateTime startDate, LocalDateTime endDate);
+    List<Experience> searchExperiences(String keywords, String country, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
+++ b/src/main/java/com/capitravel/Capitravel/service/ExperienceService.java
@@ -3,6 +3,8 @@ package com.capitravel.Capitravel.service;
 import com.capitravel.Capitravel.dto.ExperienceDTO;
 import com.capitravel.Capitravel.model.Experience;
 
+import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.List;
 
 public interface ExperienceService {
@@ -18,4 +20,6 @@ public interface ExperienceService {
     Experience updateExperience(Long id, ExperienceDTO updatedExperience);
 
     void deleteExperience(Long id);
+
+    List<Experience> searchExperiences(String keywords, String country, String city, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -1,6 +1,7 @@
 package com.capitravel.Capitravel.service.impl;
 
 import com.capitravel.Capitravel.dto.ExperienceDTO;
+import com.capitravel.Capitravel.dto.ReservationDatesDTO;
 import com.capitravel.Capitravel.exception.DuplicatedResourceException;
 import com.capitravel.Capitravel.exception.ResourceNotFoundException;
 import com.capitravel.Capitravel.model.Category;
@@ -11,9 +12,11 @@ import com.capitravel.Capitravel.repository.ExperienceRepository;
 import com.capitravel.Capitravel.repository.PropertyRepository;
 import com.capitravel.Capitravel.service.CategoryService;
 import com.capitravel.Capitravel.service.ExperienceService;
+import com.capitravel.Capitravel.service.ReservationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -35,6 +38,9 @@ public class ExperienceServiceImpl implements ExperienceService {
 
     @Autowired
     private PropertyRepository propertyRepository;
+
+    @Autowired
+    private ReservationService reservationService;
 
     @Override
     public List<Experience> getAllExperiences() {
@@ -64,6 +70,39 @@ public class ExperienceServiceImpl implements ExperienceService {
         }
         Long categoryCount = (long) validCategoryIds.size();
         return experienceRepository.findByCategoryIds(validCategoryIds, categoryCount);
+    }
+
+    @Override
+    public List<Experience> searchExperiences(String keywords, String country, String city, LocalDateTime startDate, LocalDateTime endDate) {
+        List<Experience> experiences = experienceRepository.findAll();
+
+        if (keywords != null && !keywords.isEmpty()) {
+            experiences = experiences.stream()
+                    .filter(exp -> exp.getTitle().toLowerCase().contains(keywords.toLowerCase())
+                            || exp.getProperties().stream()
+                            .anyMatch(prop -> prop.getName().toLowerCase().contains(keywords.toLowerCase())))
+                    .collect(Collectors.toList());
+        }
+
+        if (country != null && !country.isEmpty()) {
+            experiences = experiences.stream()
+                    .filter(exp -> exp.getCountry().equalsIgnoreCase(country))
+                    .collect(Collectors.toList());
+        }
+
+        if (city != null && !city.isEmpty()) {
+            experiences = experiences.stream()
+                    .filter(exp -> exp.getUbication().equalsIgnoreCase(city))
+                    .collect(Collectors.toList());
+        }
+
+        if (startDate != null && endDate != null) {
+            experiences = experiences.stream()
+                    .filter(exp -> isAvailable(exp.getId(), startDate, endDate))
+                    .collect(Collectors.toList());
+        }
+
+        return experiences;
     }
 
     @Override
@@ -160,5 +199,16 @@ public class ExperienceServiceImpl implements ExperienceService {
     private double getRandomReputation() {
         double randomValue = ThreadLocalRandom.current().nextDouble(1.0, 5.0);
         return Math.round(randomValue * 10.0) / 10.0;
+    }
+
+    private boolean isAvailable(Long experienceId, LocalDateTime startDate, LocalDateTime endDate) {
+        List<ReservationDatesDTO> reservationDates = reservationService.getReservationsByExperience(experienceId);
+
+        for (ReservationDatesDTO reservation : reservationDates) {
+            if (!(endDate.isBefore(reservation.getCheckIn()) || startDate.isAfter(reservation.getCheckOut()))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -108,7 +108,6 @@ public class ExperienceServiceImpl implements ExperienceService {
         return experiences;
     }
 
-
     @Override
     public Experience createExperience(ExperienceDTO experienceDTO) {
         if (experienceRepository.existsByTitle(experienceDTO.getTitle())) {

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -73,26 +73,29 @@ public class ExperienceServiceImpl implements ExperienceService {
     }
 
     @Override
-    public List<Experience> searchExperiences(String keywords, String country, String city, LocalDateTime startDate, LocalDateTime endDate) {
+    public List<Experience> searchExperiences(String keywords, String country, LocalDateTime startDate, LocalDateTime endDate) {
         List<Experience> experiences = experienceRepository.findAll();
 
         if (keywords != null && !keywords.isEmpty()) {
+            List<String> keywordList = Arrays.asList(keywords.toLowerCase().split(" "));
+
             experiences = experiences.stream()
-                    .filter(exp -> exp.getTitle().toLowerCase().contains(keywords.toLowerCase())
-                            || exp.getProperties().stream()
-                            .anyMatch(prop -> prop.getName().toLowerCase().contains(keywords.toLowerCase())))
+                    .filter(exp -> {
+                        String title = exp.getTitle().toLowerCase();
+                        boolean titleMatches = keywordList.stream().anyMatch(title::contains);
+
+                        boolean propertyMatches = exp.getProperties().stream()
+                                .anyMatch(prop -> keywordList.stream()
+                                        .anyMatch(keyword -> prop.getName().toLowerCase().contains(keyword)));
+
+                        return titleMatches || propertyMatches;
+                    })
                     .collect(Collectors.toList());
         }
 
         if (country != null && !country.isEmpty()) {
             experiences = experiences.stream()
-                    .filter(exp -> exp.getCountry().equalsIgnoreCase(country))
-                    .collect(Collectors.toList());
-        }
-
-        if (city != null && !city.isEmpty()) {
-            experiences = experiences.stream()
-                    .filter(exp -> exp.getUbication().equalsIgnoreCase(city))
+                    .filter(exp -> exp.getCountry().toLowerCase().contains(country.toLowerCase()))
                     .collect(Collectors.toList());
         }
 
@@ -104,6 +107,7 @@ public class ExperienceServiceImpl implements ExperienceService {
 
         return experiences;
     }
+
 
     @Override
     public Experience createExperience(ExperienceDTO experienceDTO) {


### PR DESCRIPTION
PR Description: Add Experience Search Endpoint

New functionality to search and filtering of experiences in the application. The endpoint supports multiple parameters to provide a highly flexible and tailored search functionality.

Endpoint Details
Path: GET /experiences
Description: Retrieves a list of experiences based on the provided search and filter criteria. If no parameters are provided, the endpoint returns all available experiences.

Supported Parameters

keywords (String - Optional):
Keywords to search experiences by title or description.

country (String - Optional):
The name of the country to filter experiences available in that location.

startDate (String - Optional):
A date in the format yyyy-MM-dd (or yyyy-MM-ddTHH:mm for full LocalDateTime) representing the start of a date range for filtering experiences. If time is omitted, it defaults to 00:00 of the specified day.

endDate (String - Optional):
A date in the format yyyy-MM-dd (or yyyy-MM-ddTHH:mm for full LocalDateTime) representing the end of a date range for filtering experiences. If time is omitted, it defaults to 23:59 of the specified day.


https://github.com/user-attachments/assets/1887a71a-de16-44f4-8243-07d73aaf390b

