### PR TITLE
[FEATURE][PFG5-178] removing random reputation and ratingcount starts in 0

### DIFF
--- a/src/main/java/com/capitravel/Capitravel/model/Experience.java
+++ b/src/main/java/com/capitravel/Capitravel/model/Experience.java
@@ -26,7 +26,7 @@ public class Experience {
     private String timeUnit;
     private double reputation;
 
-    private int ratingCount = 1;
+    private int ratingCount;
 
     @Lob
     @ElementCollection

--- a/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/capitravel/Capitravel/service/impl/ExperienceServiceImpl.java
@@ -166,7 +166,6 @@ public class ExperienceServiceImpl implements ExperienceService {
         experience.setTimeUnit(experienceDTO.getTimeUnit());
         experience.setCategories(categories);
         experience.setProperties(properties);
-        experience.setReputation(getRandomReputation());
         experience.setServiceHours(experienceDTO.getServiceHours());
         experience.setAvailableDays(experienceDTO.getAvailableDays());
 
@@ -238,7 +237,7 @@ public class ExperienceServiceImpl implements ExperienceService {
             throw new DuplicatedResourceException("User has already rated this experience");
         }
 
-        int currentRatingCount = experience.getRatingCount() >= 0 ? experience.getRatingCount() : 1;
+        int currentRatingCount = experience.getRatingCount();
         double currentReputation = experience.getReputation();
         double updatedReputation = ((currentReputation * currentRatingCount) + newRating) / (currentRatingCount + 1);
         updatedReputation = Math.round(updatedReputation * 10) / 10.0;
@@ -289,11 +288,6 @@ public class ExperienceServiceImpl implements ExperienceService {
         if (uniqueIds.size() < ids.size()) {
             throw new DuplicatedResourceException("Duplicated " + fieldName + " are not allowed.");
         }
-    }
-
-    private double getRandomReputation() {
-        double randomValue = ThreadLocalRandom.current().nextDouble(1.0, 5.0);
-        return Math.round(randomValue * 10.0) / 10.0;
     }
 
     private boolean isAvailable(Long experienceId, LocalDateTime startDate, LocalDateTime endDate) {


### PR DESCRIPTION
Create an experience and now starts with 0.0 reputation and 0 rating count

![image](https://github.com/user-attachments/assets/01d63707-b2cd-4435-a643-557675a360e8)

We left a review of 5.0 with user1:

![image](https://github.com/user-attachments/assets/3761b822-6696-417b-998f-764491169ea0)

We left a review of 3.0  with user 2:
![image](https://github.com/user-attachments/assets/7b202916-1759-455e-9028-34302686ff06)

The calculated reputation is now 4.0 because de average of reputation.
The average is calculated in base of the rating count, if theres a lot of reviews, your review impact less in the reputation calculation.

![image](https://github.com/user-attachments/assets/0f45a5bb-fe41-49ec-9853-d75632c66395)
